### PR TITLE
Added a "catch all" route for bad requests.

### DIFF
--- a/server.js
+++ b/server.js
@@ -9,6 +9,12 @@ app.get("/sqrt", sendSqrt)
 
 var port = process.env.PORT || 8080;
 
+app["all"]("*", function(request, response)
+{
+    response.sendStatus(404);
+    response.send("put error message here");
+});
+
 var server = app.listen(port, function()
 {
     var host = server.address().address


### PR DESCRIPTION
A "bad" request would be something like `http://cumulonimbus.io/v2/supercalifragilisticexpialidocious`, which just doesn't exist, and should return a message explaining as such. At the moment, it just returns "put error message here," but eventually, we should improve it to prompt the users with instructions or directions to our documentation, or maybe even a "did you mean?" suggestion.
